### PR TITLE
Introduce python-dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See what was baked into the last block:
 
 Use python 3.x and install the one external dependency.
 
-    pip install requests
+    pip install requests python-dotenv
 
 Run:
 

--- a/fee-feed.py
+++ b/fee-feed.py
@@ -6,9 +6,13 @@ import time
 from itertools import count, accumulate
 from bisect import bisect_left
 import statistics
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Change this to the address of your node.
-node = "http://127.0.0.1:8545"
+node = os.environ.get('RPC_URL');
 
 ModeNames = Enum('Modes', 'LATEST_FEES BASE_FEE FULLNESS SPREAD BURN')
 mode_keys = [ord('1'), ord('2'), ord('3'), ord('4'), ord('5')]

--- a/fee-feed.py
+++ b/fee-feed.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Change this to the address of your node.
-node = os.environ.get('RPC_URL');
+node = os.environ.get('RPC_URL')
 
 ModeNames = Enum('Modes', 'LATEST_FEES BASE_FEE FULLNESS SPREAD BURN')
 mode_keys = [ord('1'), ord('2'), ord('3'), ord('4'), ord('5')]


### PR DESCRIPTION
Use python-dotenv to specify node endpoint without committing to source